### PR TITLE
Add `movetime` and `resizetime` to user config

### DIFF
--- a/config.c
+++ b/config.c
@@ -23,6 +23,8 @@ struct Config config = {
 	.snap           = 8,            /* proximity of container edges to perform snap attraction */
 	.font = "monospace:pixelsize=11", /* font for titles in titlebars */
 	.ndesktops      = 10,           /* number of desktops per monitor */
+	.movetime       = 32,           /* time (ms) to redraw containers during moving */
+	.resizetime     = 64,           /* time (ms) to redraw containers during resizing */
 
 	/* dock configuration */
 	.dockwidth      = 64,           /* width of the dock (or its height, if it is horizontal) */

--- a/shod.1
+++ b/shod.1
@@ -762,6 +762,8 @@ The width of the title bar.
 .It Ic "shod.urgentBackground" Ns , Ic "shod.urgentTopShadowColor" Ns , and Ic "shod.urgentBottomShadowColor"
 The body color, light shadow color, and dark shadow color for the 3D effect
 of the borders and title bars of urgent windows.
+.It Ic "shod.moveTime" Ns \ and Ic "shod.resizeTime"
+The time in miliseconds to redraw containers during moving and resizing
 .El
 .Ss Window-dependent resources
 The resources below are named based on the class, name instance, and role of a window.

--- a/shod.h
+++ b/shod.h
@@ -8,8 +8,6 @@
 #define IGNOREUNMAP             6       /* number of unmap notifies to ignore while scanning existing clients */
 #define NAMEMAXLEN              256     /* maximum length of window's name */
 #define DROPPIXELS              30      /* number of pixels from the border where a tab can be dropped in */
-#define RESIZETIME              64      /* time to redraw containers during resizing */
-#define MOVETIME                32      /* time to redraw containers during moving */
 #define DOCKBORDER              1
 #define LEN(x)                  (sizeof(x) / sizeof((x)[0]))
 #define _SHOD_MOVERESIZE_RELATIVE       ((long)(1 << 16))
@@ -55,7 +53,9 @@
 	X(RES_NOTIFY_GAP,      "NotifGap",                  "notifGap"                  )\
 	X(RES_NOTIFY_GRAVITY,  "NotifGravity",              "notifGravity"              )\
 	X(RES_NDESKTOPS,       "NumOfDesktops",             "numOfDesktops"             )\
-	X(RES_SNAP_PROXIMITY,  "SnapProximity",             "snapProximity"             )
+	X(RES_SNAP_PROXIMITY,  "SnapProximity",             "snapProximity"             )\
+	X(RES_MOVE_TIME,       "MoveTime",                  "moveTime"                  )\
+	X(RES_RESIZE_TIME,     "ResizeTime",                "resizeTime"                )
 
 enum Resource {
 #define X(res, class, name) res,
@@ -671,6 +671,8 @@ struct Config {
 	int borderwidth;                        /* width of the border frame */
 	int titlewidth;                         /* height of the title bar */
 	int shadowthickness;                    /* thickness of the 3D shadows */
+	int movetime;                           /* time (ms) to redraw containers during moving */
+	int resizetime;                         /* time (ms) to redraw containers during resizing */
 
 	/* gravities (N for north, NE for northeast, etc) */
 	const char *notifgravity;

--- a/xdraw.c
+++ b/xdraw.c
@@ -779,6 +779,14 @@ setresources(char *xrm)
 			if ((n = strtol(value, NULL, 10)) >= 0 && n < 100)
 				config.snap = n;
 			break;
+		case RES_MOVE_TIME:
+			if ((n = strtol(value, NULL, 10)) > 0)
+				config.movetime = n;
+			break;
+		case RES_RESIZE_TIME:
+			if ((n = strtol(value, NULL, 10)) > 0)
+				config.resizetime = n;
+			break;
 		default:
 			break;
 		}

--- a/xevents.c
+++ b/xevents.c
@@ -1008,7 +1008,7 @@ mouseresize(int type, void *obj, int xroot, int yroot, enum Octant o)
 					*nh += dy;
 				}
 			}
-			if (ev.xmotion.time - lasttime > RESIZETIME) {
+			if (ev.xmotion.time - lasttime > config.resizetime) {
 				if (type == FLOAT_MENU) {
 					menumoveresize(menu);
 					menudecorate(menu, 0);
@@ -1070,7 +1070,7 @@ mousemove(Window win, int type, void *p, int xroot, int yroot, enum Octant o)
 			break;
 		case MotionNotify:
 			moved = 1;
-			if (ev.xmotion.time - lasttime > MOVETIME) {
+			if (ev.xmotion.time - lasttime > config.movetime) {
 				x = ev.xmotion.x_root - xroot;
 				y = ev.xmotion.y_root - yroot;
 				if (type == FLOAT_MENU) {
@@ -1176,7 +1176,7 @@ mouseretile(struct Container *c, struct Column *cdiv, struct Row *rdiv, int xpre
 					break;
 				}
 			}
-			if (ev.xmotion.time - lasttime > RESIZETIME) {
+			if (ev.xmotion.time - lasttime > config.resizetime) {
 				containercalccols(c);
 				containermoveresize(c, 0);
 				containerdecorate(c, cdiv, rdiv, 0, 0);


### PR DESCRIPTION
The default values for the `MOVETIME` and `RESIZETIME` macros are below the refresh rate that most people will be using (see #33). I left the defaults the same but I moved them to the `Config` struct and made them configurable via Xresources so it's more convenient and straightforward for people to use the values that best suit their system without having to recompile the window manager.